### PR TITLE
adding travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+dist: xenial
+language: python
+python:
+  - "3.7"
+install:
+  - pip install -e .
+  - pip install -r requirements.txt
+script: pytest

--- a/objects/hub.py
+++ b/objects/hub.py
@@ -3,21 +3,21 @@ import json
 import base64
 
 class Hub:
-    """An object to connect to dockerhub. Does not store username or password.
-    Any user information will be entered at execution.
-    """
-    def __init__(self, regis, uname, upass):
-        self.regis = regis
-	self.uname = uname
-	self.upass = base64.b64decode(upass)
-	#self.org = org
-	self.org_list = ['ppc64le','ibmcom']
-	self.header = ''
+	"""An object to connect to dockerhub. Does not store username or password.
+	Any user information will be entered at execution.
+	"""
+	def __init__(self, regis, uname, upass):
+		self.regis = regis
+		self.uname = uname
+		self.upass = base64.b64decode(upass)
+		#self.org = org
+		self.org_list = ['ppc64le','ibmcom']
+		self.header = ''
 
-    def token_auth(self):
+	def token_auth(self):
 		# obtain token
 		r = requests.post('https://' + self.regis + '/v2/users/login/',
-					json={"username":self.uname, "password":self.upass})
+			json={"username":self.uname, "password":self.upass})
 
 		r.raise_for_status()
 		token = json.loads(r.text)["token"]

--- a/objects/image.py
+++ b/objects/image.py
@@ -47,7 +47,7 @@ class App:
 
 		for image_obj in self.sub_images:
 			if image_obj.name is None or image_obj.name == "":
-				print "gotcha in verify()"
+				print("gotcha in verify()")
 			#iterate thru images in app and set the app.is_bad var based on image info		
 			if image_obj.exist_in_repo == False:
 		 		self.is_bad = True
@@ -217,7 +217,7 @@ class Image:
 		#this list of data contains ALL the info about each tag on 1 webpage.
 		self.add_data(json.loads(r.text))
 		logging.debug('get_image_tag: tag name:%s  %s', self.tags[itr], self.data[itr])
-		#print pp_json(data)
+		#print(pp_json(data))
 
 # class imageTag:
 # 	#imageTagLatest:

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,9 @@
+from setuptools import setup
+from setuptools import find_packages
+
+setup(name='ContainerAnalysis',
+      version='0.1',
+      description='An application to query different registries and repos to run analytics on Docker Containers.',
+      author='Ethan Hansen & Mick Tarsel',
+      packages=find_packages(),
+      zip_safe=False)

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -1,0 +1,6 @@
+import pytest
+
+from utils.tests import travis_trial
+
+def test_travis_1():
+	assert(travis_trial() == True)

--- a/utils/crawler.py
+++ b/utils/crawler.py
@@ -75,7 +75,7 @@ def get_images_from_repo(repo_pages, repo_count, regis, org, header):
 	#range(start,end,step) so from page=1 to page=repo_pages+1 cause python range starts at 0 -> n-1
 	for i in range(1,repo_pages+1):
 		repo_url = 'https://' + regis + '/v2/repositories/' + org + '/?page='+ str(i) +'&page_size=100'
-		print repo_url
+		print(repo_url)
 		r = requests.get(repo_url, headers=header)
 		#checkStatusCode(r, repo_url)
 		data = json.loads(r.text)
@@ -85,13 +85,13 @@ def get_images_from_repo(repo_pages, repo_count, regis, org, header):
 			repo_extra = int(repo_count % 100) #gotta do this again to avoid another var in func call
 			for j in range(repo_extra):
 				image_name = data["results"][j]["name"]
-				print (j, image_name)
+				print(j, image_name)
 			break #last page so no more repos.
 
 		#otherwise we have 100 images on this page for repo
 		for j in range(100):
 			image_name = data["results"][j]["name"]
-			print ("(dockerhub, %s, %s)"% (org, image_name))
+			print("(dockerhub, %s, %s)"% (org, image_name))
 
 #NEVER CALLED. can be used in the future as a crawler.gets all images in the list of organizations
 def queryHub():

--- a/utils/indexparser.py
+++ b/utils/indexparser.py
@@ -173,7 +173,7 @@ def get_app_info(app_obj, yaml_file):
 					#TODO ibm-eventstreams-dev lands here with "ibmcom" as the repo!
 					#repo is not a list and has no slash
 	else: 
-		print "\n Cannot locate any repos for images. \n NADA! \n"
+		print("\n Cannot locate any repos for images. \n NADA! \n")
 
 	#NOTE: number tags != number of repos
 	parse_image_repo(app_obj)

--- a/utils/tests.py
+++ b/utils/tests.py
@@ -7,6 +7,11 @@ from objects.image import Image
 
 from utils.indexparser import get_tarfile
 
+#Just making sure travis CI works for now
+def travis_trial():
+	print("It works")
+	return True
+
 def output_app_keywords(main_image, f):
 	""" use keywords from App. no for loop so outputs only once"""
 
@@ -144,19 +149,19 @@ def get_registries(yaml_doc):
 
 def print_obj(app_obj):
 
-	print "\nApp: %s \nLen Images: %s \n Sub Images: %s \n "%(app_obj.name, str(len(app_obj.images)), str(len(app_obj.sub_images)))
+	print("\nApp: %s \nLen Images: %s \n Sub Images: %s \n "%(app_obj.name, str(len(app_obj.images)), str(len(app_obj.sub_images))))
 
-	print "keywords"
-	print "----"
+	print("keywords")
+	print("----")
 	for key in app_obj.keywords:
-		print key
+		print(key)
 
 	for image_obj in app_obj.sub_images:
-		print "\nimage name: %s"%(image_obj.name)
-		print "image org: %s"%(image_obj.org)
-		print "Num tags: %s"%(str(len(image_obj.tags)))
+		print("\nimage name: %s"%(image_obj.name))
+		print("image org: %s"%(image_obj.org))
+		print("Num tags: %s"%(str(len(image_obj.tags))))
 		for tag in image_obj.tags:
-			print "tag: %s"%(tag)
+			print("tag: %s"%(tag))
 
 
 def testit(app_name, yaml_doc):
@@ -183,10 +188,10 @@ def testit(app_name, yaml_doc):
 	get_tarfile(app_obj) #Download tarballs and start parsing
 
 	if str(len(app_obj.images)) == "0":
-		print app_obj.name
+		print(app_obj.name)
 		print("THIS app has no tags. Likely not parsed correctly")
 		print("\nCheck out:")
-		print "\t cat ./Applications/%s/values.yaml"%(app_obj.name)
+		print("\t cat ./Applications/%s/values.yaml"%(app_obj.name))
 		print("\nbye bye")
 		sys.exit()
 
@@ -194,19 +199,19 @@ def testit(app_name, yaml_doc):
 	yaml_doc = add_header_to_yaml() # add creds to top of yaml file
 	hub_list = get_registries(yaml_doc)
 
-	print "\n Begin test\n app_obj.image =? app_obj.tags"
-	print len(app_obj.images)
-	print len(app_obj.tags)
+	print("\n Begin test\n app_obj.image =? app_obj.tags")
+	print(len(app_obj.images))
+	print(len(app_obj.tags))
 	for i in range(len(app_obj.images)):
 		
 		name = str(app_obj.images[i])
 		org = str(app_obj.clean_repos[i])
 
 		if len(app_obj.tags) == 0:
-			print "NO CONTAINERS"
+			print("NO CONTAINERS")
 			container = "Not found!"
 		else: 
-			#print app_obj.images
+			#print(app_obj.images)
 			if len(app_obj.tags) < len(app_obj.images):
 				container = str(app_obj.tags[0])
 			else:


### PR DESCRIPTION
Adding Travis CI testing to this project, just for python 3.7 for now. Partially addresses #1. Changes made to support that change to 3.7:

- objects/hub.py had inconsistent use of spaces and tabs, now all tabs
- `print` statements now `print()` statements
- new files added: [travis.yml, setup.py, tests/test_general.py]
- new `travis_trial()` function added to utils/tests.py

[Link to branch Travis build](https://travis-ci.org/EthanHans3n/ContainerAnalysis/builds/556523204)

If this is merged, a Travis CI badge should be added to the readme like this:
[![Build Status](https://travis-ci.org/EthanHans3n/ContainerAnalysis.svg?branch=master)](https://travis-ci.org/EthanHans3n/ContainerAnalysis)

Signed-off-by: Ethan Hansen <1ethanhansen@gmail.com>