### PR TITLE
pr and non-pr tests Fixes #16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,12 @@ script:
   - curl $USER_YAML_URL > user.yaml
   #Runs tests of specific functions nicely (see tests/*.py)
   - pytest
-  #A bash script handles the rest so this file doesn't get too messy
-  - chmod +x tests/bash_tests.sh
-  - ./tests/bash_tests.sh
+  #Two bash scripts handle the rest so this file doesn't get too messy
+  - chmod +x tests/nPR_tests.sh
+  - chmod +x tests/pr_okay_tests.sh
+  - if [ $TRAVIS_PULL_REQUEST != false ]; then 
+        ./tests/pr_okay_tests.sh;
+    else
+        ./tests/nPR_tests.sh;
+        ./tests/pr_okay_tests.sh;
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,17 @@ install:
   - pip install -e .
   - pip install -r requirements.txt
 script:
-  #Download user.yaml file from a super secret URL that we enter as a Travis Environment variable
-  - curl $USER_YAML_URL > user.yaml
   #Runs tests of specific functions nicely (see tests/*.py)
   - pytest
   #Two bash scripts handle the rest so this file doesn't get too messy
   - chmod +x tests/nPR_tests.sh
   - chmod +x tests/pr_okay_tests.sh
+  #If it is a PR build, we can only run certain tests
   - if [ $TRAVIS_PULL_REQUEST != false ]; then 
-        ./tests/pr_okay_tests.sh;
-    else
-        ./tests/nPR_tests.sh;
-        ./tests/pr_okay_tests.sh;
+      ./tests/pr_okay_tests.sh;
+    else  #Otherwise, we can run everything
+      #Download user.yaml file from a super secret URL that we enter as a Travis Environment variable
+      curl $USER_YAML_URL > user.yaml
+      ./tests/nPR_tests.sh;
+      ./tests/pr_okay_tests.sh;
     fi

--- a/tests/nPR_tests.sh
+++ b/tests/nPR_tests.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 #test different args to get-image-info
-python get-image-info.py --help
 python get-image-info.py user.yaml
 python get-image-info.py user.yaml --debug
 
@@ -13,3 +12,7 @@ if [ $(head -1 results.csv | sed 's/[^,]//g' | wc -c) != 11 ]; then
 echo "Wrong number of columns in results";
 exit 1;	#travis build should fail if it get the wrong number of columns
 fi
+
+#tests if container-output.log exists
+if [ ! -f container-output.log ]; then exit 1; fi
+

--- a/tests/pr_okay_tests.sh
+++ b/tests/pr_okay_tests.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+#All the tests in this file can be run w/o user.yaml
+#and without secure Travis environment variables
+
+#Run python get-image-info with different arguments
+python get-image-info.py --help


### PR DESCRIPTION
Fixes #16 by splitting travis tests into those that need the secure environment variables and those that don't, then using a Travis-supplied variable to decide whether it is okay to use the secure environment variable.

Signed-off-by: Ethan Hansen <1ethanhansen@gmail.com>

last one just ran npr

Signed-off-by: Ethan Hansen <1ethanhansen@gmail.com>

test to ensure .log created

Signed-off-by: Ethan Hansen <1ethanhansen@gmail.com>