### PR TITLE
--test option added, new tests created

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,11 @@ script:
         ./tests/pr_okay_tests.sh;
     else
         curl $USER_YAML_URL > user.yaml;
-        curl https://gist.githubusercontent.com/EthanHans3n/e04fd56109d6ab78691085f64e011165/raw/b6ec497f253c88a4811ba7ae027e2207d7a67e5e/test_index.yaml > test_index.yaml;
         ./tests/nPR_tests.sh;
         ./tests/pr_okay_tests.sh;
     fi
+  #get these two for pytest
+  - curl https://gist.githubusercontent.com/EthanHans3n/e04fd56109d6ab78691085f64e011165/raw/b6ec497f253c88a4811ba7ae027e2207d7a67e5e/test_index.yaml > test_index.yaml
+  - curl https://gist.githubusercontent.com/EthanHans3n/0bf9763d8f5c30950b5e7cd46371ff14/raw/523e47f3e7535cf88e9632aae20874abe794de74/user.yaml > user.yaml
   #Runs tests of specific functions nicely (see tests/*.py)
   - pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ install:
   - pip install -e .
   - pip install -r requirements.txt
 script:
-  #Runs tests of specific functions nicely (see tests/*.py)
-  - pytest
   #Two bash scripts handle the rest so this file doesn't get too messy
   - chmod +x tests/nPR_tests.sh
   - chmod +x tests/pr_okay_tests.sh
@@ -15,6 +13,9 @@ script:
         ./tests/pr_okay_tests.sh;
     else
         curl $USER_YAML_URL > user.yaml;
+        curl https://gist.githubusercontent.com/EthanHans3n/e04fd56109d6ab78691085f64e011165/raw/b6ec497f253c88a4811ba7ae027e2207d7a67e5e/test_index.yaml > test_index.yaml;
         ./tests/nPR_tests.sh;
         ./tests/pr_okay_tests.sh;
     fi
+  #Runs tests of specific functions nicely (see tests/*.py)
+  - pytest

--- a/get-image-info.py
+++ b/get-image-info.py
@@ -27,7 +27,7 @@ def main(args):
 	#either local or remote
 	index_yaml_loc = get_index_yaml(args)
 
-	app_list, need_keywords_list = parse_index_yaml(index_yaml_loc) #a list of Application objects
+	app_list, need_keywords_list = parse_index_yaml(index_yaml_loc, args.test_names) #a list of Application objects
 
 	output_f = setup_output_file()
 

--- a/index.yaml
+++ b/index.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+entries:
+  ibm-ace-dashboard-dev:
+  - created: 2019-07-08T18:42:25.828804364Z
+    description: IBM App Connect Enterprise dashboard
+    digest: 5a5cb37cc48157b0ce75e46f8c898669bb2f68e06b23ffbf5f7f9d2a184df1c6
+    icon: https://raw.githubusercontent.com/ot4i/ace-docker/master/app_connect_light_256x256.png
+    keywords:
+    - Limited
+    - amd64
+    - ICP
+    - ICPRHOCP
+    - ACE
+    - Integration
+    - IIB
+    - WMB
+    - MQSI
+    - Websphere
+    - Message
+    - Broker
+    - Bus
+    kubeVersion: '>=1.11.0'
+    name: ibm-ace-dashboard-dev
+    tillerVersion: '>=2.9.1'
+    urls:
+    - https://raw.githubusercontent.com/IBM/charts/master/repo/stable/ibm-ace-dashboard-dev-2.0.0.tgz
+    version: 2.0.0

--- a/tests/nPR_tests.sh
+++ b/tests/nPR_tests.sh
@@ -1,18 +1,43 @@
 #!/bin/bash
 
-#test different args to get-image-info
-python get-image-info.py user.yaml
-python get-image-info.py user.yaml --debug
-python get-image-info.py user.yaml --keep
+#set the whole script to exit if any command fails
+set -e
 
 #gets number of columns in results.csv
 #head -l outputs the first row of the file
 #sed removes everything expect commas
 #wc -c gives the character count (includes \n)
-if [ $(head -1 archives/results-$(date +"%d-%b-%Y").csv | sed 's/[^,]//g' | wc -c) != 11 ]; then
-echo "Wrong number of columns in results";
-exit 1;	#travis build should fail if it get the wrong number of columns
-fi
+check_num_columns () {
+	if [ $(head -1 archives/results-$(date +"%d-%b-%Y").csv | sed 's/[^,]//g' | wc -c) != 11 ]; then
+	echo "Wrong number of columns in results";
+	exit 1;	#travis build should fail if it get the wrong number of columns
+	fi
+}
+
+#gets number of lines in results.csv
+check_num_rows () {
+	if [ $(cat archives/results-$(date +"%d-%b-%Y").csv | xargs -l echo | wc -l) == 1 ]; then
+	echo "Only 1 row in results!";
+	exit 1;
+	fi
+}
+
+#test different args to get-image-info
+python get-image-info.py user.yaml
+check_num_columns
+check_num_rows
+
+python get-image-info.py user.yaml --debug
+check_num_columns
+check_num_rows
+
+python get-image-info.py user.yaml --keep
+check_num_columns
+check_num_rows
+
+python get-image-info.py user.yaml --test ibm-cam
+check_num_columns
+check_num_rows
 
 #tests if container-output.log exists
 if [ ! -f container-output.log ]; then exit 1; fi

--- a/tests/pr_okay_tests.sh
+++ b/tests/pr_okay_tests.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+#set the whole script to exit if any command fails
+set -e
+
 #All the tests in this file can be run w/o user.yaml
 #and without secure Travis environment variables
 

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -1,6 +1,0 @@
-import pytest
-
-from utils.setup_utils import travis_trial
-
-def test_travis_1():
-	assert(travis_trial() == True)

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -1,0 +1,35 @@
+import pytest
+
+from objects.hub import Hub
+from objects.image import App
+from objects.image import Image
+
+#test __init__ from objects.hub.Hub
+def test_make_hub():
+	new_hub = Hub("im", "sorry", "dave")
+
+
+#test __init__ from objects.image.App
+def test_make_app():
+	new_app = App("im", "afraid")
+
+	new_app.add_keyword("i")
+	assert(len(new_app.keywords) == 1)
+
+	new_app.verify()
+	assert(new_app.is_bad == True)
+
+
+#test __init__ from objects.image.Image
+def test_make_image():
+	global new_image
+	new_image = Image("cant", "let", "you")
+
+	new_image.add_tag("do")
+	assert(len(new_image.tags) == 1)
+
+	new_image.add_data("that")
+	assert(len(new_image.data) == 1)
+
+	new_image.add_arch("the_game")
+	assert(len(new_image.archs) == 1)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,17 @@
 import pytest
 
 from utils.crawler import get_repo_pages
+from utils.setup_utils import progress_bar
+from utils.setup_utils import parse_creds
+from utils.setup_utils import parse_index_yaml
+from utils.setup_utils import travis_trial
 
+#Just a sanity check, if this fails, something is VERY wrong
+def test_travis_1():
+	assert(travis_trial() == True)
+
+
+#test get_repo_pages from crawler
 def test_get_repo_pages_10():
         assert(get_repo_pages(10) == 1)
 
@@ -17,3 +27,28 @@ def test_get_repo_pages_999():
 def test_get_repo_pages_1000():
         assert(get_repo_pages(1000) == 10)
 
+
+#test progress_bar function from setup_utils
+def test_progress_bar_1_100():
+	assert(progress_bar(1, 100) == 1)
+
+def test_progress_bar_1_50():
+	assert(progress_bar(1, 50) == 2)
+
+def test_progress_bar_466_693():
+	assert(progress_bar(466, 693) == 67)
+
+def test_progress_bar_385_745():
+	assert(progress_bar(385, 745) == 51)
+
+
+#test parse_creds function from setup_utils
+def test_parse_creds():
+	assert(parse_creds("user.yaml")[0].regis == "hub.docker.com")
+
+
+#test parse_index_yaml from setup_utils
+def test_parse_index_yaml():
+	app_list, need_keywords_list = parse_index_yaml("test_index.yaml")
+	assert(app_list[0].name == "ibm-ace-dashboard-dev")
+	assert(need_keywords_list == [])


### PR DESCRIPTION
Fixes #7 

Summary of changes made in this PR:
* added --test option
  * after --test have any number (>0) of space-separated app names to test
  * eg: `... --test ibm-cam ibm-istio`
* added many python tests to test individual functions
  * 4 tests for utils.setup_utils.progress_bar
  * 1 test for utils.setup_utils.parse_creds
  * 1 test for utils.setup_utils.parse_index_yaml
  * 1 test for the Hub object
  * 3 tests for the App object
  * 4 tests for the Image object
* in nPR_tests: 
  * the number of columns is checked after every option to `get-image-info`
  * check the number of rows after every option to `get-image-info`
  * curl a test_index.yaml to use with testing parse_index_yaml
* in both nPR and pr tests `set -e` is enabled to exit the whole script if one command fails
* re-arranged .travis.yml to run unit tests after integration tests
* moved travis_trial to test_utils and made test_objects.py
* some default arguments added to functions that make testing easier

Link to Travis CI full build (not just PR build):
https://travis-ci.com/EthanHans3n/ContainerAnalysis/builds/119721161

Signed-off-by: Ethan Hansen <1ethanhansen@gmail.com>