### PR TITLE
--test option added, new tests created

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,5 @@ script:
         ./tests/nPR_tests.sh;
         ./tests/pr_okay_tests.sh;
     fi
-  #get these two for pytest
-  - curl https://gist.githubusercontent.com/EthanHans3n/e04fd56109d6ab78691085f64e011165/raw/b6ec497f253c88a4811ba7ae027e2207d7a67e5e/test_index.yaml > test_index.yaml
-  - curl https://gist.githubusercontent.com/EthanHans3n/b430383436a350b149192c3c0d2744cb/raw/f986e16539bbd37768d369e9d78a153864cea93a/test_user.yaml > test_user.yaml
   #Runs tests of specific functions nicely (see tests/*.py)
   - pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ install:
   - pip install -e .
   - pip install -r requirements.txt
 script:
-  #Runs tests of specific functions nicely (see tests/*.py)
-  - pytest
   #Two bash scripts handle the rest so this file doesn't get too messy
   - chmod +x tests/nPR_tests.sh
   - chmod +x tests/pr_okay_tests.sh
@@ -18,3 +16,8 @@ script:
         ./tests/nPR_tests.sh;
         ./tests/pr_okay_tests.sh;
     fi
+  #get these two for pytest
+  - curl https://gist.githubusercontent.com/EthanHans3n/e04fd56109d6ab78691085f64e011165/raw/b6ec497f253c88a4811ba7ae027e2207d7a67e5e/test_index.yaml > test_index.yaml
+  - curl https://gist.githubusercontent.com/EthanHans3n/b430383436a350b149192c3c0d2744cb/raw/f986e16539bbd37768d369e9d78a153864cea93a/test_user.yaml > test_user.yaml
+  #Runs tests of specific functions nicely (see tests/*.py)
+  - pytest

--- a/docs/test_index.yaml
+++ b/docs/test_index.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+entries:
+  ibm-ace-dashboard-dev:
+  - created: 2019-07-08T18:42:25.828804364Z
+    description: IBM App Connect Enterprise dashboard
+    digest: 5a5cb37cc48157b0ce75e46f8c898669bb2f68e06b23ffbf5f7f9d2a184df1c6
+    icon: https://raw.githubusercontent.com/ot4i/ace-docker/master/app_connect_light_256x256.png
+    keywords:
+    - Limited
+    - amd64
+    - ICP
+    - ICPRHOCP
+    - ACE
+    - Integration
+    - IIB
+    - WMB
+    - MQSI
+    - Websphere
+    - Message
+    - Broker
+    - Bus
+    kubeVersion: '>=1.11.0'
+    name: ibm-ace-dashboard-dev
+    tillerVersion: '>=2.9.1'
+    urls:
+    - https://raw.githubusercontent.com/IBM/charts/master/repo/stable/ibm-ace-dashboard-dev-2.0.0.tgz
+    version: 2.0.0

--- a/docs/test_user.yaml
+++ b/docs/test_user.yaml
@@ -1,0 +1,3 @@
+registries:
+  hub.docker.com:
+    ibmdev: MTAwecVyZC0=

--- a/get-image-info.py
+++ b/get-image-info.py
@@ -27,7 +27,7 @@ def main(args):
 	#either local or remote
 	index_yaml_loc = get_index_yaml(args)
 
-	app_list, need_keywords_list = parse_index_yaml(index_yaml_loc) #a list of Application objects
+	app_list, need_keywords_list = parse_index_yaml(index_yaml_loc, args.test_names) #a list of Application objects
 
 	output_f = setup_output_file()
 

--- a/tests/nPR_tests.sh
+++ b/tests/nPR_tests.sh
@@ -1,18 +1,43 @@
 #!/bin/bash
 
-#test different args to get-image-info
-python get-image-info.py user.yaml
-python get-image-info.py user.yaml --debug
-python get-image-info.py user.yaml --keep
+#set the whole script to exit if any command fails
+set -e
 
 #gets number of columns in results.csv
 #head -l outputs the first row of the file
 #sed removes everything expect commas
 #wc -c gives the character count (includes \n)
-if [ $(head -1 archives/results-$(date +"%d-%b-%Y").csv | sed 's/[^,]//g' | wc -c) != 11 ]; then
-echo "Wrong number of columns in results";
-exit 1;	#travis build should fail if it get the wrong number of columns
-fi
+check_num_columns () {
+	if [ $(head -1 archives/results-$(date +"%d-%b-%Y").csv | sed 's/[^,]//g' | wc -c) != 11 ]; then
+	echo "Wrong number of columns in results";
+	exit 1;	#travis build should fail if it get the wrong number of columns
+	fi
+}
+
+#gets number of lines in results.csv
+check_num_rows () {
+	if [ $(cat archives/results-$(date +"%d-%b-%Y").csv | xargs -l echo | wc -l) == 1 ]; then
+	echo "Only 1 row in results!";
+	exit 1;
+	fi
+}
+
+#test different args to get-image-info
+python get-image-info.py user.yaml
+check_num_columns
+check_num_rows
+
+python get-image-info.py user.yaml --debug
+check_num_columns
+check_num_rows
+
+python get-image-info.py user.yaml --keep
+check_num_columns
+check_num_rows
+
+python get-image-info.py user.yaml --test ibm-cam
+check_num_columns
+check_num_rows
 
 #tests if container-output.log exists
 if [ ! -f container-output.log ]; then exit 1; fi

--- a/tests/pr_okay_tests.sh
+++ b/tests/pr_okay_tests.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+#set the whole script to exit if any command fails
+set -e
+
 #All the tests in this file can be run w/o user.yaml
 #and without secure Travis environment variables
 

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -1,6 +1,0 @@
-import pytest
-
-from utils.setup_utils import travis_trial
-
-def test_travis_1():
-	assert(travis_trial() == True)

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -1,0 +1,35 @@
+import pytest
+
+from objects.hub import Hub
+from objects.image import App
+from objects.image import Image
+
+#test __init__ from objects.hub.Hub
+def test_make_hub():
+	new_hub = Hub("im", "sorry", "dave")
+
+
+#test __init__ from objects.image.App
+def test_make_app():
+	new_app = App("im", "afraid")
+
+	new_app.add_keyword("i")
+	assert(len(new_app.keywords) == 1)
+
+	new_app.verify()
+	assert(new_app.is_bad == True)
+
+
+#test __init__ from objects.image.Image
+def test_make_image():
+	global new_image
+	new_image = Image("cant", "let", "you")
+
+	new_image.add_tag("do")
+	assert(len(new_image.tags) == 1)
+
+	new_image.add_data("that")
+	assert(len(new_image.data) == 1)
+
+	new_image.add_arch("the_game")
+	assert(len(new_image.archs) == 1)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -44,11 +44,11 @@ def test_progress_bar_385_745():
 
 #test parse_creds function from setup_utils
 def test_parse_creds():
-	assert(parse_creds("test_user.yaml")[0].regis == "hub.docker.com")
+	assert(parse_creds("docs/test_user.yaml")[0].regis == "hub.docker.com")
 
 
 #test parse_index_yaml from setup_utils
 def test_parse_index_yaml():
-	app_list, need_keywords_list = parse_index_yaml("test_index.yaml")
+	app_list, need_keywords_list = parse_index_yaml("docs/test_index.yaml")
 	assert(app_list[0].name == "ibm-ace-dashboard-dev")
 	assert(need_keywords_list == [])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,17 @@
 import pytest
 
 from utils.crawler import get_repo_pages
+from utils.setup_utils import progress_bar
+from utils.setup_utils import parse_creds
+from utils.setup_utils import parse_index_yaml
+from utils.setup_utils import travis_trial
 
+#Just a sanity check, if this fails, something is VERY wrong
+def test_travis_1():
+	assert(travis_trial() == True)
+
+
+#test get_repo_pages from crawler
 def test_get_repo_pages_10():
         assert(get_repo_pages(10) == 1)
 
@@ -17,3 +27,28 @@ def test_get_repo_pages_999():
 def test_get_repo_pages_1000():
         assert(get_repo_pages(1000) == 10)
 
+
+#test progress_bar function from setup_utils
+def test_progress_bar_1_100():
+	assert(progress_bar(1, 100) == 1)
+
+def test_progress_bar_1_50():
+	assert(progress_bar(1, 50) == 2)
+
+def test_progress_bar_466_693():
+	assert(progress_bar(466, 693) == 67)
+
+def test_progress_bar_385_745():
+	assert(progress_bar(385, 745) == 51)
+
+
+#test parse_creds function from setup_utils
+def test_parse_creds():
+	assert(parse_creds("test_user.yaml")[0].regis == "hub.docker.com")
+
+
+#test parse_index_yaml from setup_utils
+def test_parse_index_yaml():
+	app_list, need_keywords_list = parse_index_yaml("test_index.yaml")
+	assert(app_list[0].name == "ibm-ace-dashboard-dev")
+	assert(need_keywords_list == [])

--- a/utils/setup_utils.py
+++ b/utils/setup_utils.py
@@ -30,7 +30,7 @@ def mkdir_p(path):
 #prints a progress bar as a process runs with
 #how many items are complete, how many need to complete,
 #and the length of the bar on the screen
-def progress_bar(num, total, length):
+def progress_bar(num, total, length=50):
 	#get decimal and integer percent done
 	proportion = num / total
 	percent = int(proportion * 100)
@@ -63,6 +63,8 @@ def setup_logging():
 	parser.add_argument("-i", "--index", help="A index.yaml file from a Helm Chart", type=argparse.FileType('r'))
 
 	parser.add_argument("-k", "--keep", help="Keeps old values and chart files", action="store_true", dest="keep_files")
+
+	parser.add_argument("-t", "--test", help="tests a list of specific app names (1 or more input(s))", nargs='+', dest="test_names")
 		
 	args = parser.parse_args()
 		
@@ -100,7 +102,7 @@ def get_index_yaml(args):
 		url = "https://raw.githubusercontent.com/IBM/charts/master/repo/stable/index.yaml"
 		return urllib.request.urlretrieve(url)[0]	#gets index.yaml and returns localFileName
 
-def parse_index_yaml(index_file_loc):
+def parse_index_yaml(index_file_loc, wanted_apps=None):
 	app_list = []
 	need_keywords_list = []
 
@@ -110,17 +112,22 @@ def parse_index_yaml(index_file_loc):
 	#keys = MainImage.name, values=other info about the app
 	for k, v in index_yaml_doc["entries"].items():	
 		app_name = k.replace('/', '')
-		url_for_app = "https://raw.githubusercontent.com/IBM/charts/master/stable/{}/".format(app_name)
 
-		try:
-			keywords = v[0]['keywords']
-		except:
-			need_keywords_list.append(app_name)
+		#if we didn't specify --test or we specified this app, make app
+		if (wanted_apps == None or app_name in wanted_apps):
+			url_for_app = "https://raw.githubusercontent.com/IBM/charts/master/stable/{}/".format(app_name)
+			
+			keywords = []
 
-		main_image = App(app_name, url_for_app)
-		for key in keywords:
-			main_image.add_keyword(key)
-		app_list.append(main_image)
+			try:
+				keywords = v[0]['keywords']
+			except:
+				need_keywords_list.append(app_name)
+
+			main_image = App(app_name, url_for_app)
+			for key in keywords:
+				main_image.add_keyword(key)
+			app_list.append(main_image)
 	
 	return app_list, need_keywords_list #currently just apps with names and base urls
 


### PR DESCRIPTION
Fixes #7 

Summary of changes made in this PR:
* --test option added which allows for user to enter specific app_name(s) they would like to test
* new tests added for Travis and some old tests improved

Summary of changes to each file:
* .travis.yml : re-arranging and curling files for use in unit tests
* get-image-info.py : pass app names we want to test into parse_index_yaml
* tests/nPR_tests.sh : checking # of rows and columns after every run of get-image-info
* tests/pr_okay_tests.sh : `set -e` makes the whole script exit if any command errors'
* remove tests/test_general.py
* create tests/test_objects.py : new file that tests creating and calling methods of different objects
* tests/test_utils.py : tests for assorted utility functions
* utils/setup_utils.py : created needed code for --test option

Link to Travis CI full build (not just PR build):
https://travis-ci.com/EthanHans3n/ContainerAnalysis/builds/119852538

Signed-off-by: Ethan Hansen <1ethanhansen@gmail.com>
