### PR TITLE
Fixes #40 - Cross-validate with GSA dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ Applications/
 *.swp
 generated_input.yaml
 archives/
+dash-charts.json
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/get-image-info.py
+++ b/get-image-info.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from utils.setup_utils import *
 
 
-def main(args):
+def main(args, start_time):
 	#storage variables
 	creds_file_loc = str(os.getcwd() + "/" + args.user.name)
 	
@@ -31,12 +31,14 @@ def main(args):
 		#cleanup from last run
 		shutil.rmtree(str(os.getcwd() + "/Applications"), ignore_errors=True)
 
+	dash_dict = get_dashboard_json()
+
 	num_tracker = 0
 
 	#for each app, get a lot of info on them
 	for app in app_list:
 		num_tracker += 1
-		progress_bar(num_tracker, len(app_list), 50)
+		progress_bar(num_tracker, len(app_list), start_time, 50)
 
 		dest_dir = "{}/Applications/{}/".format(os.getcwd(), app.name)
 		mkdir_p(dest_dir)	#Create the Applications/app/ dir
@@ -65,20 +67,24 @@ def main(args):
 
 	diff_last_files()
 
-	#TODO - output names of bad apps at end of log
-	print("\n========\n")
+	print("\n==== CONFLICT WITH DASHBOARD ====\n")
+	for app in app_list:
+		if not app.matches_dashboard(dash_dict):
+			print(app.name)
+
+	print("\n==== BAD APPS ====\n")
 	i = 0
 	for app in app_list:
-		if app.is_bad == True:
+		if app.is_bad:
 			i += 1
 			print(app.name)
-	print(i)
+	print("Total: {}".format(i))
 
 if __name__ == "__main__":
 	start_time = datetime.now()
 
 	args = setup_logging()
-	main(args)
+	main(args, start_time)
 
 	end_time = datetime.now()
 	print("Time to run program: {}".format(end_time - start_time))

--- a/objects/image.py
+++ b/objects/image.py
@@ -30,10 +30,13 @@ class App:
 		self.Charts_exists = False
 		self.is_bad = False # something did't parse correctly so its causing problems
 		self.product_name = '' #taken from README file of app
+		self.archs = []
 
 
 	def add_keyword(self, keyword):
 		self.keywords.append(keyword)
+		if (keyword in ['amd64', 'ppc64le', 's390x']):
+			self.archs.append(keyword)
 
 	def verify(self):
 		"""iterate thru an App's sub images to make sure we have all the info we need.
@@ -200,7 +203,7 @@ class App:
 			if (len(nested_lookup('keywords', document=chart_yaml_doc)) > 0):
 				keywords = nested_lookup('keywords', document=chart_yaml_doc)
 				for key in keywords[0]:
-					self.add_keyword(key)
+					self.add_keyword(key)		
 
 	def clean_image_repo(self):
 		"""from list of repo strings, get image names and repos.
@@ -313,6 +316,15 @@ class App:
 
 			# From here, all the vars are set for the output.
 			self.sub_images.append(image_obj)
+
+	def matches_dashboard(self, dashboard_file):
+		if (dashboard_file is not None):
+			archs_from_dash = dashboard_file[self.name]["architectures"]
+			archs_from_dash.sort()
+			self.archs.sort()
+			return self.archs == archs_from_dash
+		else:
+			return True
 
 	def output_app_keywords(self, f):
 		""" use keywords from App. no for loop so outputs only once"""

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -19,6 +19,11 @@ def test_make_app():
 	new_app.verify()
 	assert(new_app.is_bad == True)
 
+	fake_data = {"im": { "architectures" : []}}
+	assert(new_app.matches_dashboard(fake_data))
+
+	assert(new_app.matches_dashboard(None))
+
 
 #test __init__ from objects.image.Image
 def test_make_image():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -29,16 +29,20 @@ def test_get_repo_pages_1000():
 
 #test progress_bar function from setup_utils
 def test_progress_bar_1_100():
-	assert(progress_bar(1, 100) == 1)
+	start_time = datetime.now()
+	assert(progress_bar(1, 100, start_time) == 1)
 
 def test_progress_bar_1_50():
-	assert(progress_bar(1, 50) == 2)
+	start_time = datetime.now()
+	assert(progress_bar(1, 50, start_time) == 2)
 
 def test_progress_bar_466_693():
-	assert(progress_bar(466, 693) == 67)
+	start_time = datetime.now()
+	assert(progress_bar(466, 693, start_time) == 67)
 
 def test_progress_bar_385_745():
-	assert(progress_bar(385, 745) == 51)
+	start_time = datetime.now()
+	assert(progress_bar(385, 745, start_time) == 51)
 
 
 #test parse_creds function from setup_utils

--- a/utils/setup_utils.py
+++ b/utils/setup_utils.py
@@ -7,6 +7,7 @@ import sys
 import os
 import errno
 import difflib
+from json import load
 
 from objects.hub import Hub
 from objects.image import App
@@ -31,14 +32,16 @@ def mkdir_p(path):
 #prints a progress bar as a process runs with
 #how many items are complete, how many need to complete,
 #and the length of the bar on the screen
-def progress_bar(num, total, length=50):
+def progress_bar(num, total, start_time, length=50):
 	#get decimal and integer percent done
 	proportion = num / total
 	percent = int(proportion * 100)
 	#get number of octothorpes to display
 	size = int(proportion * length)
+	# Get runtime to display
+	runtime = str(datetime.now() - start_time)
 	#display [###   ] NN% done
-	display = '[' + ('#' * size) + (' ' * (length - size)) + '] ' + str(percent) + '% done'
+	display = '[' + ('#' * size) + (' ' * (length - size)) + '] ' + str(percent) + '% done ' + runtime
 	#write with stdout to allow for in-place printing
 	sys.stdout.write(display)
 	sys.stdout.flush()
@@ -73,7 +76,7 @@ def setup_logging():
 
 	# let argparse do the work for us
 	logging.basicConfig(level=args.loglevel,filename='container-output.log',
-						format='%(levelname)s:%(message)s')
+						format='%(asctime)s ~ %(levelname)s:\n%(message)s\n')
 
 	return args
 
@@ -162,7 +165,7 @@ def diff_last_files():
 	try:
 		yesterday_f_commas = open(yesterday_file_loc, "r").readlines()
 	except:
-		print("Yesterday's file not found, could not diff files")
+		print("\nYesterday's file not found, could not diff files")
 		return "Yesterday not found"
 	today_lines = [l.replace(",", "") for l in today_f_commas]
 	yesterday_lines = [l.replace(",", "") for l in yesterday_f_commas]
@@ -172,4 +175,18 @@ def diff_last_files():
 		if(line[0] != " "):  # diff-ing lines start with non-space
 			print(line)
 	return "Finished properly"
+
+def get_dashboard_json():
+	""" Tries to return a dict from dash-charts.json, if it exists.
+		If it doesn't exist, None is returned and caught later
+	"""
+
+	try:
+		dash_json_f = open("dash-charts.json", "r")
+		dash_dict = load(dash_json_f)
+		return dash_dict
+	except:
+		print("No dash-charts.json found in directory")
+		print("Disregard 'CONFLICTS' section at end of printout")
+		return None
 


### PR DESCRIPTION
Fixes #40

Summary of changes made in this PR:
* If dash-charts.json exists in the current working directory, it is loaded and parsed
* If the archs in the .json don't match those from index.yaml or Chart.yaml, that app name is printed at the end
* Minor improvements including runtime on progress bar and log output formatting changes

Summary of changes to each file:
* .gitignore : ignore dash-charts.json because don't want in repo
* get-image-info.py : changes to allow runtime on progress bar and printing output from cross-validating with dashboard data
* objects/image.py : code for `matches_dashboard` which returns true if the app's archs match what the dashboard says they should be
* tests/test_objects.py : two tests for `matches_dashboard`
* tests/test_utils.py ; editing tests to match runtime printing changes to `progress_bar`
* utils/setup_utils.py : timestamp and runtime updates and new function to load values from the dashboard data file

Signed-off-by: Ethan Hansen <1ethanhansen@gmail.com>