### PR TITLE
Fixes #31 - Save docker json locally

### DIFF
--- a/get-image-info.py
+++ b/get-image-info.py
@@ -27,7 +27,7 @@ def main(args, start_time):
 	output_f = setup_output_file()
 
 	#if we don't want to keep and use the old values.yaml
-	if (args.keep_files is not True):
+	if ((args.keep_files or args.skip_dockerhub) is not True):
 		#cleanup from last run
 		shutil.rmtree(str(os.getcwd() + "/Applications"), ignore_errors=True)
 
@@ -56,7 +56,7 @@ def main(args, start_time):
 		app.parse_values_yaml(dest_dir)
 		app.clean_image_repo()
 
-		app.repo_crawl(hub_list)
+		app.repo_crawl(hub_list, args.skip_dockerhub)
 		app.output_app_keywords(output_f)
 		app.output_CSV(output_f)
 

--- a/tests/travis_tests.sh
+++ b/tests/travis_tests.sh
@@ -35,6 +35,14 @@ python get-image-info.py docs/test_user.yaml --keep
 check_num_columns
 check_num_rows
 
+python get-image-info.py docs/test_user.yaml --local
+check_num_columns
+check_num_rows
+
+python get-image-info.py docs/test_user.yaml -kl
+check_num_columns
+check_num_rows
+
 python get-image-info.py docs/test_user.yaml --test ibm-cam
 check_num_columns
 check_num_rows

--- a/utils/setup_utils.py
+++ b/utils/setup_utils.py
@@ -66,7 +66,12 @@ def setup_logging():
 
 	parser.add_argument("-i", "--index", help="A index.yaml file from a Helm Chart", type=argparse.FileType('r'))
 
-	parser.add_argument("-k", "--keep", help="Keeps old values and chart files", action="store_true", dest="keep_files")
+	parser.add_argument("-k", "--keep", help="Keeps and uses old values and chart files",
+						action="store_true", dest="keep_files")
+
+	parser.add_argument("-l", "--local",
+						help="Skip dockerhub requests, use local data",
+						action="store_true", dest="skip_dockerhub")
 
 	parser.add_argument("-t", "--test", help="tests a list of specific app names (1 or more input(s))", nargs='+', dest="test_names")
 		

--- a/utils/setup_utils.py
+++ b/utils/setup_utils.py
@@ -60,26 +60,26 @@ def setup_logging():
 	parser = argparse.ArgumentParser(description="A script to get \
 information about images from DockerHub")
 	parser.add_argument("user", 
-			    type=argparse.FileType('r'), 
-			    help="user.yaml holds creds for Dockerhub, Github")
+						type=argparse.FileType('r'), 
+						help="user.yaml holds creds for Dockerhub, Github")
 	parser.add_argument("-d", "--debug",
-			    help="DEBUG output enabled. Logs a lot of stuff",
-			    action="store_const", dest="loglevel",
-			    const=logging.DEBUG, default=logging.WARNING)
+						help="DEBUG output enabled. Logs a lot of stuff",
+						action="store_const", dest="loglevel",
+						const=logging.DEBUG, default=logging.WARNING)
 	parser.add_argument("-v", "--verbose", 
-			    help="INFO logging enabled",
-			    action="store_const", 
-			    dest="loglevel", 
-			    const=logging.INFO)
+						help="INFO logging enabled",
+						action="store_const", 
+						dest="loglevel", 
+						const=logging.INFO)
 	parser.add_argument("-i", "--index", 
-			    help="A index.yaml file from a Helm Chart", 
-			    type=argparse.FileType('r'))
+						help="A index.yaml file from a Helm Chart", 
+						type=argparse.FileType('r'))
 	parser.add_argument("-k", "--keep", 
-			    help="Keeps old values and chart files", 
-			    action="store_true", dest="keep_files")
-    parser.add_argument("-l", "--local",
-	            help="Skip dockerhub requests, use local data",
-	            action="store_true", dest="skip_dockerhub")
+						help="Keeps old values and chart files", 
+						action="store_true", dest="keep_files")
+	parser.add_argument("-l", "--local",
+						help="Skip dockerhub requests, use local data",
+						action="store_true", dest="skip_dockerhub")
 	parser.add_argument("-t", "--test", help="tests a list of specific\
  app names (1 or more input(s))", nargs='+', dest="test_names")
 


### PR DESCRIPTION
Fixes #31 

Summary of changes made in this PR:
* new option that uses local, saved dockerhub data to speed testing runtimes further (under 10 seconds on Travis)

Summary of changes to each file:
* get-image-info.py : passing bool arg to control skipping dockerhub requests into repo_crawl and using it to save Applications folder
* objects/image.py : code needed to save dockerhub data when we are pulling it from the web and load from local files when we aren't
* tests/travis_tests.sh : new tests for --local option
* utils/setup_utils.py : Adding --local or -l option to terminal args

Signed-off-by: Ethan Hansen <1ethanhansen@gmail.com>