### PR TITLE
Fixes #26 - Adds performance tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ Applications/
 generated_input.yaml
 archives/
 dash-charts.json
+metrics.csv
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/get-image-info.py
+++ b/get-image-info.py
@@ -1,10 +1,13 @@
 """ Written by Mick Tarsel
     Optimized by Ethan Hansen"""
 import shutil
+import csv
 
 from objects.image import Image
 from datetime import datetime
+
 from utils.setup_utils import *
+from utils.teardown_utils import *
 
 
 def main(args, start_time):
@@ -29,7 +32,6 @@ def main(args, start_time):
 		#cleanup from last run
 		shutil.rmtree(str(os.getcwd() + "/Applications"),
 			      ignore_errors=True)
-	dash_dict = get_dashboard_json()
 	num_tracker = 0
 	# for each app, get a lot of info on them
 	for app in app_list:
@@ -54,22 +56,24 @@ def main(args, start_time):
 		if logging.getLogger().level == logging.DEBUG:
 			app.generate_output()
 	output_f.close()
+
 	diff_last_files()
-	print("\n==== CONFLICT WITH DASHBOARD ====\n")
-	for app in app_list:
-		if not app.matches_dashboard(dash_dict):
-			print(app.name)
-	print("\n==== BAD APPS ====\n")
-	i = 0
-	for app in app_list:
-		if app.is_bad:
-			i += 1
-			print(app.name)
-	print("Total: {}".format(i))
-	print("\n==== APP ARCHS CONFLICT WITH IMAGE ARCHS ====\n")
-	for app in app_list:
-		if not app.archs_match:
-			print(app.name)
+	dash_dict = get_dashboard_json()
+	num_xtrnl = print_external_conflict_apps(app_list, dash_dict)
+	num_bad = print_bad_apps(app_list)
+	num_ntrnl = print_internal_conflict_apps(app_list)
+
+	args_enabled = [key for key,value in vars(args).items() if value is True]
+	if logging.getLogger().level == logging.DEBUG:
+		args_enabled.append("debug")
+
+	with open("metrics.csv", "a+") as metrics_csv_file:
+		metrics_writer = csv.writer(metrics_csv_file)
+		metrics_writer.writerow([datetime.now(),
+								args_enabled,
+								datetime.now()-start_time,
+								len(app_list), num_bad,
+								num_xtrnl, num_ntrnl])
 
 
 if __name__ == "__main__":

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,59 +3,51 @@ from datetime import datetime, timedelta
 
 from utils.crawler import get_repo_pages
 from utils.setup_utils import progress_bar, parse_creds, travis_trial
-from utils.setup_utils import parse_index_yaml, diff_last_files
+from utils.setup_utils import parse_index_yaml
+from utils.teardown_utils import diff_last_files
+
+
+# test get_repo_pages from crawler
+def test_get_repo_pages_10():
+        assert(get_repo_pages(10) == 1)
+
+def test_get_repo_pages_100():
+        assert(get_repo_pages(100) == 1)
+
+def test_get_repo_pages_101():
+        assert(get_repo_pages(101) == 2)
+
+def test_get_repo_pages_999():
+        assert(get_repo_pages(999) == 10)
+
+def test_get_repo_pages_1000():
+        assert(get_repo_pages(1000) == 10)
 
 
 # Just a sanity check, if this fails, something is VERY wrong
 def test_travis_1():
     assert(travis_trial() is True)
 
-# test get_repo_pages from crawler
-def test_get_repo_pages_10():
-        assert(get_repo_pages(10) == 1)
-
-
-def test_get_repo_pages_100():
-        assert(get_repo_pages(100) == 1)
-
-
-def test_get_repo_pages_101():
-        assert(get_repo_pages(101) == 2)
-
-
-def test_get_repo_pages_999():
-        assert(get_repo_pages(999) == 10)
-
-
-def test_get_repo_pages_1000():
-        assert(get_repo_pages(1000) == 10)
-
-
 # test progress_bar function from setup_utils
 def test_progress_bar_1_100():
 	start_time = datetime.now()
 	assert(progress_bar(1, 100, start_time) == 1)
 
-
 def test_progress_bar_1_50():
 	start_time = datetime.now()
 	assert(progress_bar(1, 50, start_time) == 2)
-
 
 def test_progress_bar_466_693():
 	start_time = datetime.now()
 	assert(progress_bar(466, 693, start_time) == 67)
 
-
 def test_progress_bar_385_745():
 	start_time = datetime.now()
 	assert(progress_bar(385, 745, start_time) == 51)
 
-
 # test parse_creds function from setup_utils
 def test_parse_creds():
 	assert(parse_creds("docs/test_user.yaml")[0].regis=="hub.docker.com")
-
 
 # test parse_index_yaml from setup_utils
 def test_parse_index_yaml():
@@ -67,7 +59,6 @@ def test_parse_index_yaml():
 # test diff_last_files from setup.utils
 def test_diff_last_files_no_yesterday():
 	assert(diff_last_files() == "Yesterday not found")
-
 
 def test_diff_last_files_blank_yesterday():
 	# Create a blank yesterday results file, just to test

--- a/utils/setup_utils.py
+++ b/utils/setup_utils.py
@@ -5,10 +5,8 @@ import urllib
 import sys
 import os
 import errno
-import difflib
-from json import load
 
-from datetime import datetime, timedelta
+from datetime import datetime
 from objects.hub import Hub
 from objects.image import App
 
@@ -166,30 +164,6 @@ def setup_output_file():
 ppc64le,s390x,Tag Exists?\n")
 	return f
 
-def diff_last_files():
-	"""Opens today's file and yesterday's, reads the lines, then
-		returns the difference between (if there is a difference)
-	"""
-	# Set up file names for today and yesterday
-	today = datetime.today().strftime("%d-%b-%Y")  # 26-Jul-2019
-	today_file_loc = "archives/results-{}.csv".format(today)
-	yesterday = (datetime.today() - timedelta(1)).strftime("%d-%b-%Y")
-	yesterday_file_loc = "archives/results-{}.csv".format(yesterday)
-	# Open both files (read mode) and remove commas from every line
-	today_f_commas = open(today_file_loc, "r").readlines()
-	try:
-		yesterday_f_commas = open(yesterday_file_loc, "r").readlines()
-	except:
-		print("\nYesterday's file not found, could not diff files")
-		return "Yesterday not found"
-	today_lines = [l.replace(",", "") for l in today_f_commas]
-	yesterday_lines = [l.replace(",", "") for l in yesterday_f_commas]
-	# Print only the diff-ing lines, below progress bar
-	print("\n")
-	for line in difflib.ndiff(yesterday_lines, today_lines):
-		if(line[0] != " "):  # diff-ing lines start with non-space
-			print(line)
-	return "Finished properly"
 
 def get_dashboard_json():
 	""" Tries to return a dict from dash-charts.json, if it exists.

--- a/utils/teardown_utils.py
+++ b/utils/teardown_utils.py
@@ -1,0 +1,88 @@
+""" This is the mirror image of setup_utils.py.
+	Whereas that sript has functions to get ready for main,
+	this script has functions that finish up the program.
+"""
+
+from datetime import datetime, timedelta
+import difflib
+from json import load
+
+def print_external_conflict_apps(app_list, dash_dict):
+	"""Prints out all of the app names that conflict with dashboard."""
+	i = 0
+	print("\n==== CONFLICT WITH DASHBOARD ====\n")
+	for app in app_list:
+		if not app.matches_dashboard(dash_dict):
+			print(app.name)
+			i += 1
+	print("Total mismatched: {}".format(i))
+	return i
+
+
+def print_bad_apps(app_list):
+	""" Prints out all of the apps that didn't parse correctly
+		and those with images that weren't found in repo.
+	"""
+	i = 0
+	print("\n==== BAD APPS ====\n")
+	for app in app_list:
+		if app.is_bad:
+			print(app.name)
+			i += 1
+	print("Total bad apps: {}".format(i))
+	return i
+
+
+def print_internal_conflict_apps(app_list):
+	""" Prints apps where the app's supported architectures are not
+		the same as all of the sub-images' supported architectures.
+	"""
+	i = 0
+	print("\n==== APP ARCHS CONFLICT WITH IMAGE ARCHS ====\n")
+	for app in app_list:
+		if not app.archs_match:
+			print(app.name)
+			i +=1
+	print("Total internally conflicting apps: {}".format(i))
+	return i
+
+
+def diff_last_files():
+	""" Opens today's file and yesterday's, reads the lines, then
+		returns the difference between (if there is a difference)
+	"""
+	# Set up file names for today and yesterday
+	today = datetime.today().strftime("%d-%b-%Y")  # 26-Jul-2019
+	today_file_loc = "archives/results-{}.csv".format(today)
+	yesterday = (datetime.today() - timedelta(1)).strftime("%d-%b-%Y")
+	yesterday_file_loc = "archives/results-{}.csv".format(yesterday)
+	# Open both files (read mode) and remove commas from every line
+	today_f_commas = open(today_file_loc, "r").readlines()
+	try:
+		yesterday_f_commas = open(yesterday_file_loc, "r").readlines()
+	except:
+		print("\nYesterday's file not found, could not diff files")
+		return "Yesterday not found"
+	today_lines = [l.replace(",", "") for l in today_f_commas]
+	yesterday_lines = [l.replace(",", "") for l in yesterday_f_commas]
+	# Print only the diff-ing lines, below progress bar
+	print("\n")
+	for line in difflib.ndiff(yesterday_lines, today_lines):
+		if(line[0] != " "):  # diff-ing lines start with non-space
+			print(line)
+	return "Finished properly"
+
+
+def get_dashboard_json():
+	""" Tries to return a dict from dash-charts.json, if it exists.
+		If it doesn't exist, None is returned and caught later
+	"""
+	try:
+		dash_json_f = open("dash-charts.json", "r")
+		dash_dict = load(dash_json_f)
+		return dash_dict
+	except:
+		print("No dash-charts.json found in directory")
+		print("Disregard 'CONFLICTS' section at end of printout")
+		return None
+


### PR DESCRIPTION
Fixes #26 

Summary of changes made in this PR:
* A new file in gets created in the working directory called "metrics.csv" which contains a history of the key metrics, creating a nice summary of change over time.
* Fields logged in metrics.csv are timestamp, user options (keep, debug, local), run time, total apps checked, number of bad apps, number of apps that don't match the dashboard, and number of apps with an internal arch conflict.

Summary of changes to each file:
* .gitignore : ignoring metrics.csv
* get-image-info.py : code to get and store the metrics we want
* tests/test_utils.py : formatting fixes, changing import locations to match new teardown-utils
* utils/setup_utils.py : moved diff_last_files to teardown_utils
* utils/teardown_utils.py : new file to handle functions called once at the end of main as the function is getting ready to exit

Signed-off-by: Ethan Hansen <1ethanhansen@gmail.com>