### PR TITLE
Fixes #41 - results to slack

### DIFF
--- a/get-image-info.py
+++ b/get-image-info.py
@@ -56,13 +56,13 @@ def main(args, start_time):
 		if logging.getLogger().level == logging.DEBUG:
 			app.generate_output()
 	output_f.close()
-
-	diff_last_files()
+	sfile = open("slackfile.txt", "w+")
+	diff_last_files(sfile)
 	dash_dict = get_dashboard_json()
-	num_xtrnl = print_external_conflict_apps(app_list, dash_dict)
+	num_xtrnl = print_external_conflict_apps(app_list, dash_dict, sfile)
 	num_bad = print_bad_apps(app_list)
 	num_ntrnl = print_internal_conflict_apps(app_list)
-
+	sfile.close()
 	args_enabled = [key for key,value in vars(args).items() if value is True]
 	if logging.getLogger().level == logging.DEBUG:
 		args_enabled.append("debug")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -58,13 +58,15 @@ def test_parse_index_yaml():
 
 # test diff_last_files from setup.utils
 def test_diff_last_files_no_yesterday():
-	assert(diff_last_files() == "Yesterday not found")
-
+	sfile = open("slackfile.txt","w+")
+	assert(diff_last_files(sfile) == "Yesterday not found")
+	sfile.close()
 def test_diff_last_files_blank_yesterday():
 	# Create a blank yesterday results file, just to test
+	sfile = open("slackfile.txt","w+")
 	yesterday = (datetime.today() - timedelta(1)).strftime("%d-%b-%Y")
 	yesterday_file_loc = "archives/results-{}.csv".format(yesterday)
 	yesterday_file = open(yesterday_file_loc, "w+")
 	yesterday_file.close()
-	assert(diff_last_files() == "Finished properly")
-
+	assert(diff_last_files(sfile) == "Finished properly")
+	sfile.close()

--- a/utils/setup_utils.py
+++ b/utils/setup_utils.py
@@ -1,4 +1,5 @@
 import logging
+import subprocess
 import argparse
 import yaml
 import urllib
@@ -174,9 +175,20 @@ ppc64le,s390x,Tag Exists?\n")
 	return f
 
 
+
+def send_results(slackfile, url):
+	sfile = open(slackfile, "r+")
+	slackinfo = sfile.read()
+	if slackinfo == "":
+		print("No diff, no apps in conflict with dashboard")
+	else:
+		subprocess.call('''curl -X POST -H 'Content-type: application/json' --data '{"text": " %s " }' %s'''%(slackinfo, url) + "\n", shell=True)
+	sfile.close()
+
+
 def get_dashboard_json():
 	""" Tries to return a dict from dash-charts.json, if it exists.
-		If it doesn't exist, None is returned and caught later
+	    If it doesn't exist, None is returned and caught later
 	"""
 
 	try:

--- a/utils/teardown_utils.py
+++ b/utils/teardown_utils.py
@@ -7,14 +7,20 @@ from datetime import datetime, timedelta
 import difflib
 from json import load
 
-def print_external_conflict_apps(app_list, dash_dict):
+def print_external_conflict_apps(app_list, dash_dict, sfile):
 	"""Prints out all of the app names that conflict with dashboard."""
+	conflict_list = []
 	i = 0
 	print("\n==== CONFLICT WITH DASHBOARD ====\n")
 	for app in app_list:
 		if not app.matches_dashboard(dash_dict):
+			conflict_list.append(app.name)
 			print(app.name)
 			i += 1
+	if conflict_list != []:
+                sfile.write("\n==== CONFLICT WITH DASHBOARD ====\n")
+                for i in conflict_list:
+                        sfile.write(i)
 	print("Total mismatched: {}".format(i))
 	return i
 
@@ -47,30 +53,39 @@ def print_internal_conflict_apps(app_list):
 	return i
 
 
-def diff_last_files():
-	""" Opens today's file and yesterday's, reads the lines, then
-		returns the difference between (if there is a difference)
-	"""
-	# Set up file names for today and yesterday
-	today = datetime.today().strftime("%d-%b-%Y")  # 26-Jul-2019
-	today_file_loc = "archives/results-{}.csv".format(today)
-	yesterday = (datetime.today() - timedelta(1)).strftime("%d-%b-%Y")
-	yesterday_file_loc = "archives/results-{}.csv".format(yesterday)
-	# Open both files (read mode) and remove commas from every line
-	today_f_commas = open(today_file_loc, "r").readlines()
-	try:
-		yesterday_f_commas = open(yesterday_file_loc, "r").readlines()
-	except:
-		print("\nYesterday's file not found, could not diff files")
-		return "Yesterday not found"
-	today_lines = [l.replace(",", "") for l in today_f_commas]
-	yesterday_lines = [l.replace(",", "") for l in yesterday_f_commas]
-	# Print only the diff-ing lines, below progress bar
-	print("\n")
-	for line in difflib.ndiff(yesterday_lines, today_lines):
-		if(line[0] != " "):  # diff-ing lines start with non-space
-			print(line)
-	return "Finished properly"
+def diff_last_files(sfile):
+        """Opens today's file and yesterday's, reads the lines, then
+                returns the difference between (if there is a difference)
+        """
+        # Set up file names for today and yesterday
+        slack_list = []
+        today = datetime.today().strftime("%d-%b-%Y")  # 26-Jul-2019
+        print(today)
+        today_file_loc = "archives/results-{}.csv".format(today)
+        yesterday = (datetime.today() - timedelta(1)).strftime("%d-%b-%Y")
+        yesterday_file_loc = "archives/results-{}.csv".format(yesterday)
+        # Open both files (read mode) and remove commas from every line
+        today_f_commas = open(today_file_loc, "r").readlines()
+        try:
+                yesterday_f_commas = open(yesterday_file_loc, "r").readlines()
+        except:
+                print("\nYesterday's file not found, could not diff files")
+                return "Yesterday not found"
+        today_lines = [l.replace(",", "") for l in today_f_commas]
+        yesterday_lines = [l.replace(",", "") for l in yesterday_f_commas]
+        # Print ovnly the diff-ing lines, below progress bar
+        print("\n")
+        for line in difflib.ndiff(yesterday_lines, today_lines):
+                if(line[0] != " "):  # diff-ing lines start with non-space
+                        slack_list.append(line)
+                        print(line)
+        if slack_list != []:
+                sfile.write("==== DIFF IN RESULTS ====\n")
+                for i in slack_list:
+                        sfile.write(i)
+        return "Finished properly"
+
+
 
 
 def get_dashboard_json():


### PR DESCRIPTION
Additions to print_external_conflict_apps, diff_last_files, saves info to slackfile.txt
send_results sends slackfile.txt to slack via slackbot, not called, should only be called through Jenkins

Signed-off-by: Rye Scholin <ryescholin@gmail.com>