### PR TITLE
Fixes #59 - Format and add slack info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ generated_input.yaml
 archives/
 dash-charts.json
 metrics.csv
+slackfile.txt
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/get-image-info.py
+++ b/get-image-info.py
@@ -61,7 +61,7 @@ def main(args, start_time):
 	dash_dict = get_dashboard_json()
 	num_xtrnl = print_external_conflict_apps(app_list, dash_dict, sfile)
 	num_bad = print_bad_apps(app_list)
-	num_ntrnl = print_internal_conflict_apps(app_list)
+	num_ntrnl = print_internal_conflict_apps(app_list, sfile)
 	sfile.close()
 	args_enabled = [key for key,value in vars(args).items() if value is True]
 	if logging.getLogger().level == logging.DEBUG:

--- a/utils/teardown_utils.py
+++ b/utils/teardown_utils.py
@@ -10,19 +10,17 @@ from json import load
 def print_external_conflict_apps(app_list, dash_dict, sfile):
 	"""Prints out all of the app names that conflict with dashboard."""
 	conflict_list = []
-	i = 0
 	print("\n==== CONFLICT WITH DASHBOARD ====\n")
 	for app in app_list:
 		if not app.matches_dashboard(dash_dict):
 			conflict_list.append(app.name)
 			print(app.name)
-			i += 1
 	if conflict_list != []:
                 sfile.write("\n==== CONFLICT WITH DASHBOARD ====\n")
                 for i in conflict_list:
-                        sfile.write(i)
-	print("Total mismatched: {}".format(i))
-	return i
+                        sfile.write(i + "\n")
+	print("Total mismatched: {}".format(len(conflict_list)))
+	return len(conflict_list)
 
 
 def print_bad_apps(app_list):
@@ -39,18 +37,22 @@ def print_bad_apps(app_list):
 	return i
 
 
-def print_internal_conflict_apps(app_list):
+def print_internal_conflict_apps(app_list, sfile):
 	""" Prints apps where the app's supported architectures are not
 		the same as all of the sub-images' supported architectures.
 	"""
-	i = 0
+	conflict_list = []
 	print("\n==== APP ARCHS CONFLICT WITH IMAGE ARCHS ====\n")
 	for app in app_list:
 		if not app.archs_match:
+			conflict_list.append(app.name)
 			print(app.name)
-			i +=1
-	print("Total internally conflicting apps: {}".format(i))
-	return i
+	if conflict_list != []:
+                sfile.write("\n==== APP ARCHS CONFLICT WITH IMAGE ARCHS ====\n")
+                for i in conflict_list:
+                        sfile.write(i + "\n")
+	print("Total internally conflicting apps: {}".format(len(conflict_list)))
+	return len(conflict_list)
 
 
 def diff_last_files(sfile):


### PR DESCRIPTION
Fixes #59 

Summary of changes made in this PR:
* Formatting updates
* New info posted to slack if it exists

Summary of changes to each file:
* .gitignore : ignore slack file
* get-image-info.py : have to pass slack file object to function that gets internal inconsistencies
* utils/teardown_utils.py : cleaning some code, formatting slack outputs, and add ability to post internal conflicts to slack

Signed-off-by: Ethan Hansen <1ethanhansen@gmail.com>